### PR TITLE
ci: add workflow to deploy to pypi

### DIFF
--- a/.github/workflows/run_pytests.yaml
+++ b/.github/workflows/run_pytests.yaml
@@ -37,3 +37,32 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('tests/conftest.py') }}
       - name: Run Tests
         run: pytest --cov=./scikit_mol .
+
+ # deploy scikit_mol to pypi for tagged commits if tests pass
+  deploy:
+    needs: [ tests ]
+    name: deploy to pypi
+    runs-on: ubuntu-latest
+    # this checks that the commit is a tagged commit
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build
+      - name: Build a binary wheel and a source tarball
+        run: |
+          python -m build .
+      # push all tagged versions to pypi.org
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
This PR adds a workflow to deploy scikit_mol to pypi for commits that are tagged.

The way you use this is the following:

- develop your module on github and everytime you want to make a new release you create a tag
  ```console
  # the current latest commit on main that should be released as a new version
  $ git tag v0.1.2
  $ git push origin v0.1.2
  ```
- this will trigger the ci and build a new version of the package and deploy to pypi
- I recommend having the tags adhere to semantic versioning `vX.Y.Z`


To set up the required tokens, goto pypi and sign up.
Goto your account settings and scroll to the API token section. Create a new API token with scope for everything (note: after your project was created you can replace the token with a token that has scope only for your project)
Copy the token and add it as a secret in your github repository (Settings > Secrets > Actions, --> Create New Repository Secret) The secret name should be `PYPI_PASSWORD`.

When the deploy pipeline after a tagged commit succeeds, your new version is available on pypi.

People can then just `pip install scikit-mol`

If anything is unclear, let me know!

