### PR TITLE
Pandas output

### DIFF
--- a/scikit_mol/conversions.py
+++ b/scikit_mol/conversions.py
@@ -13,6 +13,13 @@ class SmilesToMolTransformer(BaseEstimator, TransformerMixin):
         self.parallel = parallel
         self.start_method = None  #TODO implement handling of start_method
 
+    def get_feature_names_out(self, input_features=None):
+        prefix = "molecule"
+        if input_features is not None:
+            return np.array([f'{prefix}_{name}' for name in input_features])
+        else:
+            return np.array([prefix])
+
     def fit(self, X=None, y=None):
         """Included for scikit-learn compatibility, does nothing"""
         return self

--- a/scikit_mol/descriptors.py
+++ b/scikit_mol/descriptors.py
@@ -9,6 +9,8 @@ from rdkit.ML.Descriptors.MoleculeDescriptors import MolecularDescriptorCalculat
 
 from sklearn.base import BaseEstimator, TransformerMixin
 
+from scikit_mol.utilities import get_mols_from_X
+
 
 
 class MolecularDescriptorTransformer(BaseEstimator, TransformerMixin):
@@ -99,7 +101,8 @@ class MolecularDescriptorTransformer(BaseEstimator, TransformerMixin):
 
     def _transform(self, x: List[Mol]) -> np.ndarray:
         arr = np.zeros((len(x), len(self.desc_list)))
-        for i, mol in enumerate(x):
+        mols = get_mols_from_X(x)
+        for i, mol in enumerate(mols):
             arr[i, :] = self._transform_mol(mol)
         return arr
 

--- a/scikit_mol/descriptors.py
+++ b/scikit_mol/descriptors.py
@@ -60,6 +60,9 @@ class MolecularDescriptorTransformer(BaseEstimator, TransformerMixin):
         """Descriptor names of currently selected descriptors"""
         return self._desc_list
 
+    def get_feature_names_out(self, input_features=None):
+        return np.array(self.selected_descriptors)
+
     @desc_list.setter
     def desc_list(self, desc_list):
         self._desc_list = desc_list

--- a/scikit_mol/fingerprints.py
+++ b/scikit_mol/fingerprints.py
@@ -71,9 +71,24 @@ class FpsTransformer(ABC, BaseEstimator, TransformerMixin):
         self._get_column_prefix()
         return self
 
+    def _get_mols_from_X(self, X):
+        """Get the molecules iterable from the input X"""
+        if isinstance(X, pd.DataFrame):
+            try:
+                # TODO: possibly handle the case in which a DataFrame
+                # contains multiple molecule columns (as if from a column selector transformer).
+                # In that case, the resulting array should be a concatenation of the fingerprint arrays
+                # for each molecule column.
+                return X.loc[:, "molecule"]
+            except KeyError:
+                return X.iloc[:, 0]
+        else:
+            return X
+
     def _transform(self, X):
         arr = np.zeros((len(X), self.nBits), dtype=np.int8)
-        for i, mol in enumerate(X):
+        mols = self._get_mols_from_X(X)
+        for i, mol in enumerate(mols):
             arr[i,:] = self._transform_mol(mol)
         return arr
 
@@ -321,7 +336,8 @@ class MHFingerprintTransformer(FpsTransformer):
 
     def _transform(self, X):
         arr = np.zeros((len(X), self.nBits), dtype=np.int32)
-        for i, mol in enumerate(X):
+        mols = self._get_mols_from_X(X)
+        for i, mol in enumerate(mols):
             arr[i,:] = self._transform_mol(mol)
         return arr
 

--- a/scikit_mol/fingerprints.py
+++ b/scikit_mol/fingerprints.py
@@ -17,6 +17,7 @@ from scipy.sparse import lil_matrix
 from scipy.sparse import vstack
 
 from sklearn.base import BaseEstimator, TransformerMixin
+from scikit_mol.utilities import get_mols_from_X
 
 from abc import ABC, abstractmethod
 
@@ -79,23 +80,9 @@ class FpsTransformer(ABC, BaseEstimator, TransformerMixin):
         self._get_column_prefix()
         return self
 
-    def _get_mols_from_X(self, X):
-        """Get the molecules iterable from the input X"""
-        if isinstance(X, pd.DataFrame):
-            try:
-                # TODO: possibly handle the case in which a DataFrame
-                # contains multiple molecule columns (as if from a column selector transformer).
-                # In that case, the resulting array should be a concatenation of the fingerprint arrays
-                # for each molecule column.
-                return X.loc[:, "molecule"]
-            except KeyError:
-                return X.iloc[:, 0]
-        else:
-            return X
-
     def _transform(self, X):
         arr = np.zeros((len(X), self.nBits), dtype=self._dtype_fingerprint)
-        mols = self._get_mols_from_X(X)
+        mols = get_mols_from_X(X)
         for i, mol in enumerate(mols):
             arr[i,:] = self._transform_mol(mol)
         return arr

--- a/scikit_mol/utilities.py
+++ b/scikit_mol/utilities.py
@@ -53,3 +53,18 @@ class CheckSmilesSanitazion:
             self.errors = pd.DataFrame({'SMILES':X_errors})
 
             return X_out, X_errors
+
+
+def get_mols_from_X(X):
+        """Get the molecules iterable from the input X"""
+        if isinstance(X, pd.DataFrame):
+            try:
+                # TODO: possibly handle the case in which a DataFrame
+                # contains multiple molecule columns (as if from a column selector transformer).
+                # In that case, the resulting array should be a concatenation of the fingerprint arrays
+                # for each molecule column.
+                return X.loc[:, "molecule"]
+            except KeyError:
+                return X.iloc[:, 0]
+        else:
+            return X

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from urllib.request import urlopen
 
 import pandas as pd
 import pytest
+import sklearn
 
 
 TEST_DATA_URL = "https://ndownloader.figshare.com/files/25747817"
@@ -45,3 +46,10 @@ def data_pth(tmp_path_factory) -> Path:
 @pytest.fixture()
 def data(data_pth) -> pd.DataFrame:
     yield pd.read_csv(data_pth)
+
+@pytest.fixture(scope="module")
+def pandas_output():
+    """Set sklearn to output pandas dataframes"""
+    sklearn.set_config(transform_output="pandas")
+    yield
+    sklearn.set_config(transform_output="default")

--- a/tests/test_desctransformer.py
+++ b/tests/test_desctransformer.py
@@ -72,6 +72,13 @@ def test_descriptor_transformer_parallel(mols_list, default_descriptor_transform
     assert(len(features2) == len(mols_list))
     assert(len(features2[0]) == len(Descriptors._descList))
 
+def test_descriptor_transformer_pandas_output(mols_list, default_descriptor_transformer, selected_descriptor_transformer, pandas_output):
+    for mols in  [mols_list, pd.Series(mols_list), pd.Series(mols_list, name="hello")]:
+        for transformer in [default_descriptor_transformer, selected_descriptor_transformer]:
+            features = transformer.transform(mols)
+            assert isinstance(features, pd.DataFrame)
+            assert features.columns.tolist() == transformer.selected_descriptors
+
 # This test may fail on windows and mac (due to spawn rather than fork?)
 # def test_descriptor_transformer_parallel_speedup(mols_list, default_descriptor_transformer):
 #     n_phys_cpus = joblib.cpu_count(only_physical_cores=True)

--- a/tests/test_smilestomol.py
+++ b/tests/test_smilestomol.py
@@ -41,4 +41,8 @@ def test_descriptor_transformer_parallel(smiles_list, smilestomol_transformer):
     assert all([ a == b for a, b in zip(smiles_list, [Chem.MolToSmiles(mol) for mol in mol_list])])
     
 
-    
+def test_pandas_output(smiles_list, smilestomol_transformer, pandas_output):
+    for to_convert in [smiles_list, pd.Series(smiles_list), pd.Series(smiles_list, name="hello")]:
+        mols = smilestomol_transformer.transform(to_convert)
+        assert isinstance(mols, pd.DataFrame)
+        assert mols.columns.tolist() == ["molecule"]

--- a/tests/test_smilestomol.py
+++ b/tests/test_smilestomol.py
@@ -45,4 +45,5 @@ def test_pandas_output(smiles_list, smilestomol_transformer, pandas_output):
     for to_convert in [smiles_list, pd.Series(smiles_list), pd.Series(smiles_list, name="hello")]:
         mols = smilestomol_transformer.transform(to_convert)
         assert isinstance(mols, pd.DataFrame)
+        assert mols.shape[0] == len(smiles_list)
         assert mols.columns.tolist() == ["molecule"]

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -89,6 +89,7 @@ def test_transformer_pandas_output(SLC6A4_subset, pandas_output):
             pipeline.fit(X_smiles)
             X_transformed = pipeline.transform(X_smiles)
             assert isinstance(X_transformed, pd.DataFrame), f"the output of {FP_name} is not a pandas dataframe"
+            assert X_transformed.shape[0] == len(X_smiles), f"the number of rows in the output of {FP_name} is not equal to the number of samples"
             assert len(X_transformed.columns) == pipeline.named_steps["FP"].nBits, f"the number of columns in the output of {FP_name} is not equal to the number of bits"
             print(f"\nfitting and transforming completed")
 

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -19,12 +19,6 @@ from scikit_mol.fingerprints import MACCSKeysFingerprintTransformer, RDKitFinger
 
 from fixtures import SLC6A4_subset
 
-@pytest.fixture
-def pandas_output():
-    sklearn.set_config(transform_output="pandas")
-    yield
-    sklearn.set_config(transform_output="default")
-
 def test_transformer(SLC6A4_subset):
     # load some toy data for quick testing on a small number of samples
     X_smiles, Y = SLC6A4_subset.SMILES, SLC6A4_subset.pXC50


### PR DESCRIPTION
Closes #38 .

All scikit-mol transformer classes now support the scikit-learn `set_output` API. They can keep the data in DataFrames with meaningful column names.