### PR TITLE
add conda install steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ Users can install latest tagged release from pip
 
     pip install scikit-mol
 
+or from conda-forge
+
+    conda install -c conda-forge scikit-mol
+
 Bleeding edge
 
     pip install git+https://github.com:EBjerrum/scikit-mol.git


### PR DESCRIPTION
No worries if you rather have users install from pypi and not mention conda-forge at all