### PR TITLE
Safe inference and parallel bug fixes

### DIFF
--- a/scikit_mol/descriptors.py
+++ b/scikit_mol/descriptors.py
@@ -153,7 +153,8 @@ class MolecularDescriptorTransformer(BaseEstimator, TransformerMixin):
             n_chunks = (
                 n_processes if n_processes is not None else multiprocessing.cpu_count()
             )  # TODO, tune the number of chunks per child process
-
+            if n_chunks > len(x):
+                n_chunks = len(x)
             with get_context(self.start_method).Pool(processes=n_processes) as pool:
                 params = self.get_params()
                 x_chunks = np.array_split(x, n_chunks)

--- a/scikit_mol/fingerprints/baseclasses.py
+++ b/scikit_mol/fingerprints/baseclasses.py
@@ -171,6 +171,8 @@ class BaseFpsTransformer(ABC, BaseEstimator, TransformerMixin):
                 n_processes if n_processes is not None else multiprocessing.cpu_count()
             )
 
+            if len((X)) < n_chunks:
+                n_chunks = len(X)
             with get_context(self.start_method).Pool(processes=n_processes) as pool:
                 x_chunks = np.array_split(X, n_chunks)
                 # TODO check what is fastest, pickle or recreate and do this only for classes that need this

--- a/scikit_mol/safeinference.py
+++ b/scikit_mol/safeinference.py
@@ -69,7 +69,11 @@ def filter_invalid_rows(fill_value=np.nan, warn_on_invalid=False):
             else:
                 reduced_y = None
 
-            result = func(obj, reduced_X, reduced_y, *args, **kwargs)
+            # handle case where all rows are masked e.g single invalid input is passed
+            if isinstance(X, np.ma.MaskedArray) and X.mask.all():
+                result = np.array([])
+            else:
+                result = func(obj, reduced_X, reduced_y, *args, **kwargs)
 
             if result is None:
                 return None

--- a/scikit_mol/safeinference.py
+++ b/scikit_mol/safeinference.py
@@ -1,6 +1,6 @@
 """Wrapper for sklearn estimators and pipelines to handle errors."""
 
-from typing import Any
+from typing import Union
 
 import numpy as np
 import pandas as pd
@@ -13,13 +13,14 @@ from sklearn.utils.metaestimators import available_if
 from .utilities import set_safe_inference_mode
 
 
+__all__ = ["SafeInferenceWrapper", "MaskedArrayError", "set_safe_inference_mode"]
+
 class MaskedArrayError(ValueError):
     """Raised when a masked array is passed but safe_inference_mode is False."""
 
     pass
 
-
-def filter_invalid_rows(fill_value=np.nan, warn_on_invalid=False):
+def filter_invalid_rows(warn_on_invalid=False, replace_value=np.nan):
     def decorator(func):
         @wraps(func)
         def wrapper(obj, X, y=None, *args, **kwargs):
@@ -30,6 +31,10 @@ def filter_invalid_rows(fill_value=np.nan, warn_on_invalid=False):
                         "Set safe_inference_mode=True to process masked arrays for inference of production models."
                     )
                 return func(obj, X, y, *args, **kwargs)
+            if not hasattr(obj, "replace_value"):
+                raise ValueError("replace_value must be set in the SafeInferenceWrapper")
+            else:
+                replace_value = obj.replace_value
 
             # Initialize valid_mask as all True
             valid_mask = np.ones(X.shape[0], dtype=bool)
@@ -70,19 +75,18 @@ def filter_invalid_rows(fill_value=np.nan, warn_on_invalid=False):
                 reduced_y = None
 
             # handle case where all rows are masked e.g single invalid input is passed
-            if isinstance(X, np.ma.MaskedArray) and X.mask.all():
+            if len(valid_indices) == 0:
                 result = np.array([])
             else:
                 result = func(obj, reduced_X, reduced_y, *args, **kwargs)
 
             if result is None:
                 return None
-
             if isinstance(result, np.ndarray):
                 if result.ndim == 1:
-                    output = np.full(X.shape[0], fill_value)
+                    output = np.full(X.shape[0], replace_value)
                 else:
-                    output = np.full((X.shape[0], result.shape[1]), fill_value)
+                    output = np.full((X.shape[0], result.shape[1]), replace_value)
                 output[valid_indices] = result
                 return output
             elif isinstance(result, pd.DataFrame):
@@ -124,7 +128,7 @@ class SafeInferenceWrapper(BaseEstimator, TransformerMixin):
         self,
         estimator: BaseEstimator,
         safe_inference_mode: bool = False,
-        replace_value=np.nan,
+        replace_value: Union[int, float, str] = np.nan,
         mask_nonfinite: bool = True,
     ):
         self.estimator = estimator

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -88,12 +88,15 @@ def chiral_smiles_list():  # Need to be a certain size, so the fingerprints reac
         ]
     ]
 
+@pytest.fixture
+def smiles_list_with_invalid(smiles_list):
+    data = smiles_list.copy()
+    data.extend(["invalid"])
+    return data
 
 @pytest.fixture
-def invalid_smiles_list(smiles_list):
-    smiles_list = smiles_list.copy()
-    smiles_list.append("Invalid")
-    return smiles_list
+def invalid_smiles_list():
+    return ["NOT MOL", "invalid", "C(=O)OX", "XC1CCCCC1"]
 
 
 _MOLS_LIST = [Chem.MolFromSmiles(smiles) for smiles in _SMILES_LIST]
@@ -115,9 +118,9 @@ def chiral_mols_list(chiral_smiles_list):
 
 
 @pytest.fixture
-def mols_with_invalid_container(invalid_smiles_list):
+def mols_with_invalid_container(smiles_list_with_invalid):
     mols = []
-    for smiles in invalid_smiles_list:
+    for smiles in smiles_list_with_invalid:
         mol = Chem.MolFromSmiles(smiles)
         if mol is None:
             mols.append(InvalidMol("TestError", f"Invalid SMILES: {smiles}"))

--- a/tests/test_desctransformer.py
+++ b/tests/test_desctransformer.py
@@ -12,7 +12,7 @@ from scikit_mol.core import SKLEARN_VERSION_PANDAS_OUT
 from fixtures import (
     mols_list,
     smiles_list,
-    invalid_smiles_list,
+    smiles_list_with_invalid,
     mols_container,
     smiles_container,
     skip_pandas_output_test,

--- a/tests/test_fptransformers.py
+++ b/tests/test_fptransformers.py
@@ -13,7 +13,7 @@ from fixtures import (
     chiral_smiles_list,
     chiral_mols_list,
     mols_with_invalid_container,
-    invalid_smiles_list,
+    smiles_list_with_invalid,
 )
 from sklearn import clone
 

--- a/tests/test_safeinferencemode.py
+++ b/tests/test_safeinferencemode.py
@@ -31,6 +31,13 @@ def smiles_pipeline():
         ]
     )
 
+@pytest.fixture
+def smiles_pipeline_trained(smiles_pipeline, SLC6A4_subset):
+    X_smiles, Y = SLC6A4_subset.SMILES, SLC6A4_subset.pXC50
+    X_smiles = X_smiles.to_frame()
+    # Train the model
+    smiles_pipeline.fit(X_smiles, Y)
+    return smiles_pipeline
 
 def test_safeinference_wrapper_basic(smiles_pipeline, SLC6A4_subset):
     X_smiles, Y = SLC6A4_subset.SMILES, SLC6A4_subset.pXC50
@@ -47,6 +54,11 @@ def test_safeinference_wrapper_basic(smiles_pipeline, SLC6A4_subset):
     assert len(predictions) == len(X_smiles)
     assert not np.any(np.isnan(predictions))
 
+def test_safeinference_wrapper_with_single_invalid_smiles(smiles_pipeline_trained):
+    set_safe_inference_mode(smiles_pipeline_trained, True)
+
+    # Test prediction
+    prediction = smiles_pipeline_trained.predict(["invalid_smiles"])
 
 def test_safeinference_wrapper_with_invalid_smiles(
     smiles_pipeline, SLC6A4_subset, invalid_smiles_list

--- a/tests/test_safeinferencemode.py
+++ b/tests/test_safeinferencemode.py
@@ -15,9 +15,18 @@ from fixtures import (
     smiles_list,
 )
 
+def equal_val(value, expected_value):
+    try:
+        if np.isnan(expected_value):
+            return np.isnan(value)
+        else:
+            return value == expected_value
+    except TypeError:
+        return value == expected_value
 
-@pytest.fixture
-def smiles_pipeline():
+
+@pytest.fixture(params=[np.nan, None, np.inf, 0, -100])
+def smiles_pipeline(request):
     return Pipeline(
         [
             ("s2m", SmilesToMolTransformer()),
@@ -25,7 +34,7 @@ def smiles_pipeline():
             (
                 "RF",
                 SafeInferenceWrapper(
-                    RandomForestRegressor(n_estimators=3, random_state=42)
+                    RandomForestRegressor(n_estimators=3, random_state=42), replace_value=request.param  
                 ),
             ),
         ]
@@ -51,14 +60,17 @@ def test_safeinference_wrapper_basic(smiles_pipeline, SLC6A4_subset):
 
     # Test prediction
     predictions = smiles_pipeline.predict(X_smiles)
+
     assert len(predictions) == len(X_smiles)
-    assert not np.any(np.isnan(predictions))
+    assert not np.any(equal_val(predictions, smiles_pipeline.named_steps["RF"].replace_value))
 
 def test_safeinference_wrapper_with_single_invalid_smiles(smiles_pipeline_trained):
     set_safe_inference_mode(smiles_pipeline_trained, True)
-
+    replace_value = smiles_pipeline_trained.named_steps["RF"].replace_value
     # Test prediction
     prediction = smiles_pipeline_trained.predict(["invalid_smiles"])
+    assert len(prediction) == 1
+    assert equal_val(prediction[0], replace_value)
 
 def test_safeinference_wrapper_with_invalid_smiles(
     smiles_pipeline, SLC6A4_subset, invalid_smiles_list
@@ -71,17 +83,15 @@ def test_safeinference_wrapper_with_invalid_smiles(
 
     # Train the model
     smiles_pipeline.fit(X_smiles, Y)
-
+    replace_value = smiles_pipeline.named_steps["RF"].replace_value
     # Create a test set with invalid SMILES
     X_test = pd.DataFrame({"SMILES": X_smiles["SMILES"].tolist() + invalid_smiles_list})
-
+    len_invalid = len(invalid_smiles_list)
     # Test prediction with invalid SMILES
     predictions = smiles_pipeline.predict(X_test)
+    invalid_predictions = predictions[-len_invalid:]
     assert len(predictions) == len(X_test)
-    assert np.any(np.isnan(predictions))
-    assert np.all(np.isnan(predictions[-1]))  # Only last should be nan
-    assert np.all(~np.isnan(predictions[:-1]))  # All others should not be nan
-
+    assert np.all(equal_val(invalid_predictions, replace_value))
 
 def test_safeinference_wrapper_without_safe_mode(
     smiles_pipeline, SLC6A4_subset, invalid_smiles_list

--- a/tests/test_sanitizer.py
+++ b/tests/test_sanitizer.py
@@ -2,7 +2,7 @@ import pytest
 import numpy as np
 import pandas as pd
 from rdkit import Chem
-from fixtures import smiles_list, invalid_smiles_list
+from fixtures import smiles_list, smiles_list_with_invalid
 from scikit_mol.utilities import CheckSmilesSanitazion
 
 
@@ -16,44 +16,44 @@ def return_mol_sanitizer():
     return CheckSmilesSanitazion(return_mol=True)
 
 
-def test_checksmilessanitation(smiles_list, invalid_smiles_list, sanitizer):
-    smiles_list_sanitized, errors = sanitizer.sanitize(invalid_smiles_list)
-    assert len(invalid_smiles_list) > len(smiles_list_sanitized)
+def test_checksmilessanitation(smiles_list, smiles_list_with_invalid, sanitizer):
+    smiles_list_sanitized, errors = sanitizer.sanitize(smiles_list_with_invalid)
+    assert len(smiles_list_with_invalid) > len(smiles_list_sanitized)
     assert all([a == b for a, b in zip(smiles_list, smiles_list_sanitized)])
     assert errors[0] == sanitizer.errors.SMILES[0]
 
 
-def test_checksmilessanitation_x_and_y(smiles_list, invalid_smiles_list, sanitizer):
+def test_checksmilessanitation_x_and_y(smiles_list, smiles_list_with_invalid, sanitizer):
     smiles_list_sanitized, y_sanitized, errors, y_errors = sanitizer.sanitize(
-        invalid_smiles_list, list(range(len(invalid_smiles_list)))
+        smiles_list_with_invalid, list(range(len(smiles_list_with_invalid)))
     )
-    assert len(invalid_smiles_list) > len(smiles_list_sanitized)
+    assert len(smiles_list_with_invalid) > len(smiles_list_sanitized)
     assert all([a == b for a, b in zip(smiles_list, smiles_list_sanitized)])
     assert errors[0] == sanitizer.errors.SMILES[0]
     # Test that y is correctly split into y_error and the rest
     assert all([a == b for a, b in zip(y_sanitized, list(range(len(smiles_list) - 1)))])
-    assert y_errors[0] == len(invalid_smiles_list) - 1  # Last smiles is invalid
+    assert y_errors[0] == len(smiles_list_with_invalid) - 1  # Last smiles is invalid
 
 
-def test_checksmilessanitation_np(smiles_list, invalid_smiles_list, sanitizer):
-    smiles_list_sanitized, errors = sanitizer.sanitize(np.array(invalid_smiles_list))
-    assert len(invalid_smiles_list) > len(smiles_list_sanitized)
+def test_checksmilessanitation_np(smiles_list, smiles_list_with_invalid, sanitizer):
+    smiles_list_sanitized, errors = sanitizer.sanitize(np.array(smiles_list_with_invalid))
+    assert len(smiles_list_with_invalid) > len(smiles_list_sanitized)
     assert all([a == b for a, b in zip(smiles_list, smiles_list_sanitized)])
     assert errors[0] == sanitizer.errors.SMILES[0]
 
 
-def test_checksmilessanitation_numpy(smiles_list, invalid_smiles_list, sanitizer):
-    smiles_list_sanitized, errors = sanitizer.sanitize(pd.Series(invalid_smiles_list))
-    assert len(invalid_smiles_list) > len(smiles_list_sanitized)
+def test_checksmilessanitation_numpy(smiles_list, smiles_list_with_invalid, sanitizer):
+    smiles_list_sanitized, errors = sanitizer.sanitize(pd.Series(smiles_list_with_invalid))
+    assert len(smiles_list_with_invalid) > len(smiles_list_sanitized)
     assert all([a == b for a, b in zip(smiles_list, smiles_list_sanitized)])
     assert errors[0] == sanitizer.errors.SMILES[0]
 
 
 def test_checksmilessanitation_return_mol(
-    smiles_list, invalid_smiles_list, return_mol_sanitizer
+    smiles_list, smiles_list_with_invalid, return_mol_sanitizer
 ):
-    smiles_list_sanitized, errors = return_mol_sanitizer.sanitize(invalid_smiles_list)
-    assert len(invalid_smiles_list) > len(smiles_list_sanitized)
+    smiles_list_sanitized, errors = return_mol_sanitizer.sanitize(smiles_list_with_invalid)
+    assert len(smiles_list_with_invalid) > len(smiles_list_sanitized)
     assert all(
         [
             a == b

--- a/tests/test_smilestomol.py
+++ b/tests/test_smilestomol.py
@@ -13,7 +13,7 @@ from scikit_mol.core import (
 )
 from fixtures import (
     smiles_list,
-    invalid_smiles_list,
+    smiles_list_with_invalid,
     smiles_container,
     skip_pandas_output_test,
 )
@@ -52,9 +52,9 @@ def test_smilestomol_clone(smilestomol_transformer):
     assert all([params[key] == params_2[key] for key in params.keys()])
 
 
-def test_smilestomol_unsanitzable(invalid_smiles_list, smilestomol_transformer):
+def test_smilestomol_unsanitzable(smiles_list_with_invalid, smilestomol_transformer):
     with pytest.raises(ValueError):
-        smilestomol_transformer.transform(invalid_smiles_list)
+        smilestomol_transformer.transform(smiles_list_with_invalid)
 
 
 def test_descriptor_transformer_parallel(smiles_container, smilestomol_transformer):
@@ -82,27 +82,27 @@ def test_smilestomol_inverse_transform(smilestomol_transformer, smiles_container
 
 
 def test_smilestomol_inverse_transform_with_invalid(
-    invalid_smiles_list, smilestomol_transformer
+    smiles_list_with_invalid, smilestomol_transformer
 ):
     smilestomol_transformer.set_params(safe_inference_mode=True)
 
     # Forward transform
-    mols = smilestomol_transformer.transform(invalid_smiles_list)
+    mols = smilestomol_transformer.transform(smiles_list_with_invalid)
 
     # Inverse transform
     result = smilestomol_transformer.inverse_transform(mols)
 
-    assert len(result) == len(invalid_smiles_list)
+    assert len(result) == len(smiles_list_with_invalid)
 
     # Check that all but the last element are the same as the original SMILES
-    for original, res in zip(invalid_smiles_list[:-1], result[:-1].flatten()):
+    for original, res in zip(smiles_list_with_invalid[:-1], result[:-1].flatten()):
         assert isinstance(res, str)
         assert original == res
 
     # Check that the last element is an InvalidMol instance
     assert isinstance(result[-1].item(), InvalidMol)
     assert "Invalid SMILES" in result[-1].item().error
-    assert invalid_smiles_list[-1] in result[-1].item().error
+    assert smiles_list_with_invalid[-1] in result[-1].item().error
 
 
 def test_smilestomol_get_feature_names_out(smilestomol_transformer):
@@ -110,11 +110,11 @@ def test_smilestomol_get_feature_names_out(smilestomol_transformer):
     assert feature_names == [DEFAULT_MOL_COLUMN_NAME]
 
 
-def test_smilestomol_safe_inference(invalid_smiles_list, smilestomol_transformer):
+def test_smilestomol_safe_inference(smiles_list_with_invalid, smilestomol_transformer):
     smilestomol_transformer.set_params(safe_inference_mode=True)
-    result = smilestomol_transformer.transform(invalid_smiles_list)
+    result = smilestomol_transformer.transform(smiles_list_with_invalid)
 
-    assert len(result) == len(invalid_smiles_list)
+    assert len(result) == len(smiles_list_with_invalid)
     assert isinstance(result, np.ndarray)
 
     # Check that all but the last element are valid RDKit Mol objects
@@ -128,7 +128,7 @@ def test_smilestomol_safe_inference(invalid_smiles_list, smilestomol_transformer
 
     # Check if the error message is correctly set for the invalid SMILES
     assert "Invalid SMILES" in last_mol.error
-    assert invalid_smiles_list[-1] in last_mol.error
+    assert smiles_list_with_invalid[-1] in last_mol.error
 
 
 @pytest.mark.skipif(
@@ -136,12 +136,12 @@ def test_smilestomol_safe_inference(invalid_smiles_list, smilestomol_transformer
     reason="Pandas output not supported in this sklearn version",
 )
 def test_smilestomol_safe_inference_pandas_output(
-    invalid_smiles_list, smilestomol_transformer, pandas_output
+    smiles_list_with_invalid, smilestomol_transformer, pandas_output
 ):
     smilestomol_transformer.set_params(safe_inference_mode=True)
-    result = smilestomol_transformer.transform(invalid_smiles_list)
+    result = smilestomol_transformer.transform(smiles_list_with_invalid)
 
-    assert len(result) == len(invalid_smiles_list)
+    assert len(result) == len(smiles_list_with_invalid)
     assert isinstance(result, pd.DataFrame)
     assert result.columns == [DEFAULT_MOL_COLUMN_NAME]
 
@@ -156,7 +156,7 @@ def test_smilestomol_safe_inference_pandas_output(
 
     # Check if the error message is correctly set for the invalid SMILES
     assert "Invalid SMILES" in last_mol.error
-    assert invalid_smiles_list[-1] in last_mol.error
+    assert smiles_list_with_invalid[-1] in last_mol.error
 
 
 @skip_pandas_output_test


### PR DESCRIPTION
Hi @EBjerrum, thank you and other contributors for making this package possible

I had a plan to contribute to the library during the Christmas holidays, but after forking it suddenly realized, that a lot of tests are failing and this PR aims to solve this prior to making any other contributions 

## Overview

This pull request includes various changes aimed at improving the handling of invalid SMILES strings, enhancing the `SafeInferenceWrapper` functionality, and updating test fixtures for better consistency. The most important changes include adjustments to chunk processing, updates to the `SafeInferenceWrapper` class, and modifications to test fixtures.

## Enhancements to chunk processing:

* `scikit_mol/descriptors.py`: Added a check to ensure `n_chunks` does not exceed the length of `X` to avoid empty chunks.
* `scikit_mol/fingerprints/baseclasses.py`: Added a check to ensure `n_chunks` does not exceed the length of `X` to avoid empty chunks.

## Updates to `SafeInferenceWrapper`:

In current version value for `replace_value` is not propagated from the `SafeInferenceWrapper` to the `filter_invalid_rows` causing the fill value to always be `np.nan` instead of actual value. Also when the input contains only invalid SMILES in the safe inference mode, empty array is passed to the estimator causing error

* `scikit_mol/safeinference.py`: Added `__all__` to export specific classes and functions, updated the `filter_invalid_rows` function to use `replace_value` from the class it is applied to, and added a check for `replace_value` in the `SafeInferenceWrapper`, added check for the case,  where all the inputs are invalid in the safe inference mode

## Modifications to test fixtures:

* `tests/fixtures.py`: Replaced the `invalid_smiles_list` fixture with `smiles_list_with_invalid` to include both valid and invalid SMILES strings, added new `invalid_smiles_list` fixture to include only invalid smiles strings
* `tests/test_safeinferencemode.py`: Updated tests to use the new `smiles_list_with_invalid` fixture and added new tests for handling single invalid SMILES and using different fill values

## Other test updates:

* `tests/test_sanitizer.py`: Updated tests to use the `smiles_list_with_invalid` fixture
* `tests/test_smilestomol.py`: Updated tests to use the `smiles_list_with_invalid` fixture.

