### PR TITLE
fix deprecation warning for DataFrame.swapaxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,3 +118,4 @@ Scikit-Mol has been developed as a community effort with contributions from peop
 - [@mikemhenry](https://github.com/mikemhenry)
 - [@c-feldmann](https://github.com/c-feldmann)
 - Mieczyslaw Torchala [@mieczyslaw](https://github.com/mieczyslaw)
+- Kyle Barbary [@kbarbary](https://github.com/kbarbary)

--- a/docs/index.md
+++ b/docs/index.md
@@ -118,3 +118,4 @@ Scikit-Mol has been developed as a community effort with contributions from peop
 - [@mikemhenry](https://github.com/mikemhenry)
 - [@c-feldmann](https://github.com/c-feldmann)
 - Mieczyslaw Torchala [@mieczyslaw](https://github.com/mieczyslaw)
+- Kyle Barbary [@kbarbary](https://github.com/kbarbary)


### PR DESCRIPTION
This PR fixes deprecation warnings about `DataFrame.swapaxes`, detailed in #49.

This deprecation warning arises from calling `np.array_split()` on a DataFrame. Unfortunately it will not be fixed between numpy and pandas, as detailed in https://github.com/numpy/numpy/issues/24889#issuecomment-1895503977. It seems that in the future it may return ndarrays instead of DataFrames.

The fix here is one possible implementation: for pandas objects, split the integer index values, then apply them to the pandas object using `iloc`.

Thanks for the great package, by the way!